### PR TITLE
Fix false-positive D405 recognition

### DIFF
--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -436,6 +436,7 @@ class ConventionChecker(object):
 
         For example, if `line` is "  Hello world!!!", returns "Hello world".
         """
+        result = re("[\w ]+").match(line.strip())
         if result is not None:
             return result.group()
 

--- a/src/pydocstyle/checker.py
+++ b/src/pydocstyle/checker.py
@@ -436,7 +436,6 @@ class ConventionChecker(object):
 
         For example, if `line` is "  Hello world!!!", returns "Hello world".
         """
-        result = re("[A-Za-z ]+").match(line.strip())
         if result is not None:
             return result.group()
 
@@ -625,7 +624,7 @@ class ConventionChecker(object):
                                                        'is_last_section'))
 
         # First - create a list of possible contexts. Note that the
-        # `following_linex` member is until the end of the docstring.
+        # `following_lines` member is until the end of the docstring.
         contexts = (SectionContext(self._get_leading_words(lines[i].strip()),
                                    lines[i - 1],
                                    lines[i],

--- a/src/tests/test_cases/sections.py
+++ b/src/tests/test_cases/sections.py
@@ -215,3 +215,14 @@ def multiple_sections():
     My attention.
 
     """
+
+
+@expect(_D213)
+def false_positive_section_prefix():
+    """Toggle the gizmo.
+
+    Arguments
+    ---------
+        attributes_are_fun: attributes for the function.
+
+    """

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,8 @@ envlist = {py27, py34, py35, py36, pypy}-{tests, install}, docs
 setenv =
     LANG=C
     LC_ALL=C
-commands = py.test --pep8 --cache-clear -vv src/tests
+# To pass arguments to py.test, use `tox [options] -- [pytest posargs]`.
+commands = py.test --pep8 --cache-clear -vv src/tests {posargs}
 deps =
     -rrequirements/runtime.txt
     -rrequirements/tests.txt


### PR DESCRIPTION
Solves #311.

The problem was that the regex split words when reached an underscore, so "arguments_bla" was caught as "arguments".